### PR TITLE
Add 4 more questions to homepage for scrollability

### DIFF
--- a/index.html
+++ b/index.html
@@ -68,7 +68,7 @@
             What does “Keyboard-Only Navigation” mean?
           </p>
           <label class="quiz__option">
-            <input type="radio" name="question2 checked" />All users must use a
+            <input type="radio" name="question2" checked />All users must use a
             mouse</label
           >
           <label class="quiz__option">
@@ -83,6 +83,145 @@
           <p class="quiz__card-answer">
             ✅ The correct answer is: All functions of the website are also
             accessible using only the keyboard
+          </p>
+        </article>
+        <article class="quiz__card">
+          <button
+            class="quiz__card-bookmark"
+            aria-label="Bookmark this question"
+          >
+            <img src="assets/icons/bookmark.svg" alt="" />
+          </button>
+          <header class="quiz__card-header">
+            <h2 class="quiz__card-title">Question</h2>
+            <div class="quiz__card-tags">
+              <span class="quiz__card-tag">#accessibility</span>
+              <span class="quiz__card-tag">#beginner</span>
+            </div>
+          </header>
+
+          <p class="quiz__card-question">Why are ARIA labels important?</p>
+          <label class="quiz__option">
+            <input type="radio" name="question3" />They help screen readers
+            interpret elements correctly</label
+          >
+          <label class="quiz__option">
+            <input type="radio" name="question3" />They change the button
+            colors</label
+          >
+          <label class="quiz__option">
+            <input type="radio" name="question3" />They replace images</label
+          >
+          <button class="quiz__card-submit">Show Answer</button>
+          <p class="quiz__card-answer" hidden>
+            ✅ The correct answer is: They help screen readers interpret
+            elements correctly
+          </p>
+        </article>
+        <article class="quiz__card">
+          <button
+            class="quiz__card-bookmark"
+            aria-label="Bookmark this question"
+          >
+            <img src="assets/icons/bookmark.svg" alt="" />
+          </button>
+          <header class="quiz__card-header">
+            <h2 class="quiz__card-title">Question</h2>
+            <div class="quiz__card-tags">
+              <span class="quiz__card-tag">#accessibility</span>
+              <span class="quiz__card-tag">#beginner</span>
+            </div>
+          </header>
+
+          <p class="quiz__card-question">
+            Which measure improves the readability of text on websites?
+          </p>
+          <label class="quiz__option">
+            <input type="radio" name="question4" checked />High contrast between
+            text and background</label
+          >
+          <label class="quiz__option">
+            <input type="radio" name="question4" />Small font sizes</label
+          >
+          <label class="quiz__option">
+            <input type="radio" name="question4" />Text in all caps</label
+          >
+          <button class="quiz__card-submit">Show Answer</button>
+          <p class="quiz__card-answer">
+            ✅ The correct answer is: High contrast between text and background
+          </p>
+        </article>
+        <article class="quiz__card">
+          <button
+            class="quiz__card-bookmark"
+            aria-label="Bookmark this question"
+          >
+            <img src="assets/icons/bookmark.svg" alt="" />
+          </button>
+          <header class="quiz__card-header">
+            <h2 class="quiz__card-title">Question</h2>
+            <div class="quiz__card-tags">
+              <span class="quiz__card-tag">#accessibility</span>
+              <span class="quiz__card-tag">#beginner</span>
+            </div>
+          </header>
+
+          <p class="quiz__card-question">
+            Why is responsive design important for accessibility?
+          </p>
+          <label class="quiz__option">
+            <input type="radio" name="question5" />It ensures the website works
+            well on different devices and screen sizes, benefiting all users —
+            including those who zoom or use assistive tech</label
+          >
+          <label class="quiz__option">
+            <input type="radio" name="question5" />It makes websites look more
+            modern</label
+          >
+          <label class="quiz__option">
+            <input type="radio" name="question5" />It removes the need for alt
+            text</label
+          >
+          <button class="quiz__card-submit">Show Answer</button>
+          <p class="quiz__card-answer" hidden>
+            ✅ The correct answer is: It ensures the website works well on
+            different devices and screen sizes, benefiting all users — including
+            those who zoom or use assistive tech
+          </p>
+        </article>
+        <article class="quiz__card">
+          <button
+            class="quiz__card-bookmark"
+            aria-label="Bookmark this question"
+          >
+            <img src="assets/icons/bookmark.svg" alt="" />
+          </button>
+          <header class="quiz__card-header">
+            <h2 class="quiz__card-title">Question</h2>
+            <div class="quiz__card-tags">
+              <span class="quiz__card-tag">#accessibility</span>
+              <span class="quiz__card-tag">#beginner</span>
+            </div>
+          </header>
+
+          <p class="quiz__card-question">
+            What improves accessibility for users with cognitive disabilities?
+          </p>
+          <label class="quiz__option">
+            <input type="radio" name="question6" checked />Clear, simple
+            language and predictable layouts</label
+          >
+          <label class="quiz__option">
+            <input type="radio" name="question6" />Fast-moving animations</label
+          >
+          <label class="quiz__option">
+            <input type="radio" name="question6" />Long paragraphs without
+            breaks</label
+          >
+          <button class="quiz__card-submit">Show Answer</button>
+          <p class="quiz__card-answer">
+            ✅ The correct answer is: Clear, simple language and predictable
+            layouts
           </p>
         </article>
       </section>


### PR DESCRIPTION
## Added more questions to home page

This PR adds 4 additional questions to `index.html` to make the page scrollable and demonstrate multiple question cards.

### Changes:
- Added questions 3-6 with topics on accessibility
- Mix of answered (with `checked`) and unanswered states
- All questions follow the same structure as existing cards
- Total of 6 questions on home page now

### Question states:
- Question 1, 3, 5: Unanswered (no selection)
- Question 2, 4, 6: Answered (showing different user interactions)

This ensures the home page is scrollable as required and provides enough content for CSS styling.